### PR TITLE
Fix HTML validation warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Mozingo UX</title>
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&amp;display=swap" rel="stylesheet" />
   <style>
     html {
       scroll-padding-top: 120px;


### PR DESCRIPTION
## Summary
- escape ampersand in Google Fonts link

## Testing
- `tidy -errors -quiet index.html`

------
https://chatgpt.com/codex/tasks/task_e_68506242e6d4832090ba46d845b2ae0f